### PR TITLE
Fix clone_id mismatch between db and vjl_groups/inter_intra in single-cell mode

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,15 @@
+Version 1.5.0.999: Unreleased
+-------------------------------------------------------------------------------
+
+Bug fixes:
+
++ Fixed `identicalClones`, `hierarchicalClones`, and `spectralClones` in
+  single-cell mode with `summarize_clones=TRUE`: `vjl_groups` and
+  `inter_intra` could reference `clone_id` values no longer matching those in
+  `db`, due to clone ids being renumbered again after merging light chain
+  data without updating those summaries. (Issue #52)
+
+
 Version 1.5.0: May 5, 2026
 -------------------------------------------------------------------------------
 

--- a/R/Functions.R
+++ b/R/Functions.R
@@ -8,7 +8,8 @@
 #' @slot   db              \code{data.frame} of repertoire data including with clonal identifiers in 
 #'                         the column specified during processing.
 #' @slot   vjl_groups      \code{data.frame} of clonal summary, including sequence count, V gene, 
-#'                         J gene, junction length, and clone counts.
+#'                         J gene, junction length, and clone counts. In single-cell mode, this 
+#'                         summary is defined from heavy/long-chain partitions (IGH or TRB/TRD).
 #' @slot   inter_intra     \code{data.frame} containing minimum inter (between) and maximum intra 
 #'                         (within) clonal distances.
 #' @slot   eff_threshold   effective cut-off separating the inter (between) and intra (within) clonal 
@@ -804,8 +805,9 @@ plotCloneSummary <- function(data, xmin=NULL, xmax=NULL, breaks=NULL,
 #'                              The default is \code{NULL} for no action.
 #' @param    summarize_clones   if \code{TRUE} performs a series of analysis to assess the clonal landscape
 #'                              and returns a \link{ScoperClones} object. If \code{FALSE} (default) then
-#'                              a modified input \code{db} is returned. When grouping by \code{fields}, 
-#'                              \code{summarize_clones} should be \code{FALSE}.
+#'                              a modified input \code{db} is returned. In single-cell mode, \code{vjl_groups}
+#'                              summarizes heavy/long-chain partitions used for clustering. When grouping by
+#'                              \code{fields}, \code{summarize_clones} should be \code{FALSE}.
 #' 
 #' @return
 #' If \code{summarize_clones=FALSE} (default) a modified \code{data.frame} is returned with clone identifiers in the 
@@ -823,12 +825,11 @@ plotCloneSummary <- function(data, xmin=NULL, xmax=NULL, breaks=NULL,
 #' or \code{c("TRA", "TRB", "TRD", "TRG")} for TCR sequences. Otherwise, the operation will exit and 
 #' return an error message.
 #' 
-#' Under single-cell mode with paired-chain sequences, there is a choice of whether 
-#' grouping should be done by (a) using IGH (BCR) or TRB/TRD (TCR) sequences only or
-#' (b) using IGH plus IGK/IGL (BCR) or TRB/TRD plus TRA/TRG (TCR) sequences. 
-#' This is governed by the \code{only_heavy} argument. There is also choice as to whether 
-#' inferred clones should be split by the light/short chain (IGK, IGL, TRA, TRG) following 
-#' heavy/long chain clustering, which is governed by the \code{split_light} argument.
+#' In single-cell mode, clonal clustering is performed using heavy/long chains only
+#' (IGH for BCR or TRB/TRD for TCR). The \code{only_heavy=FALSE} and
+#' \code{split_light=TRUE} options are deprecated and ignored with warnings.
+#' Consequently, \code{vjl_groups} summarizes heavy/long-chain V/J/junction-length
+#' partitions and does not define groups from light/short chains.
 #' 
 #' In single-cell mode, clonal clustering will not be performed on data where cells are 
 #' assigned multiple heavy/long chain sequences (IGH, TRB, TRD). If observed, the operation 
@@ -953,7 +954,8 @@ identicalClones <- function(db, method=c("nt", "aa"), junction="junction",
 #' @param    summarize_clones   if \code{TRUE} performs a series of analysis to assess the clonal landscape
 #'                              and returns a \link{ScoperClones} object. If \code{FALSE} (default) then
 #'                              a modified input \code{db} is returned with clone identifiers in the specified 
-#'                              `clone` column. When grouping by \code{fields}, 
+#'                              `clone` column. In single-cell mode, \code{vjl_groups} summarizes
+#'                              heavy/long-chain partitions used for clustering. When grouping by \code{fields},
 #'                              \code{summarize_clones} should be \code{FALSE}. 
 #' @param   seq_id              The column containing sequence ids
 #'
@@ -1025,12 +1027,11 @@ identicalClones <- function(db, method=c("nt", "aa"), junction="junction",
 #' or \code{c("TRA", "TRB", "TRD", "TRG")} for TCR sequences. Otherwise, the operation will exit and 
 #' return an error message.
 #' 
-#' Under single-cell mode with paired-chain sequences, there is a choice of whether 
-#' grouping should be done by (a) using IGH (BCR) or TRB/TRD (TCR) sequences only or
-#' (b) using IGH plus IGK/IGL (BCR) or TRB/TRD plus TRA/TRG (TCR) sequences. 
-#' This is governed by the \code{only_heavy} argument. There is also choice as to whether 
-#' inferred clones should be split by the light/short chain (IGK, IGL, TRA, TRG) following 
-#' heavy/long chain clustering, which is governed by the \code{split_light} argument.
+#' In single-cell mode, clonal clustering is performed using heavy/long chains only
+#' (IGH for BCR or TRB/TRD for TCR). The \code{only_heavy=FALSE} and
+#' \code{split_light=TRUE} options are deprecated and ignored with warnings.
+#' Consequently, \code{vjl_groups} summarizes heavy/long-chain V/J/junction-length
+#' partitions and does not define groups from light/short chains.
 #' 
 #' In single-cell mode, clonal clustering will not be performed on data where cells are 
 #' assigned multiple heavy/long chain sequences (IGH, TRB, TRD). If observed, the operation 
@@ -1149,8 +1150,9 @@ hierarchicalClones <- function(db, threshold, method=c("nt", "aa"), linkage=c("s
 #'                              The default is \code{NULL} for no action.
 #' @param    summarize_clones   if \code{TRUE} performs a series of analysis to assess the clonal landscape
 #'                              and returns a \link{ScoperClones} object. If \code{FALSE} (default) then
-#'                              a modified input \code{db} is returned. When grouping by \code{fields}, 
-#'                              \code{summarize_clones} should be \code{FALSE}.
+#'                              a modified input \code{db} is returned. In single-cell mode, \code{vjl_groups}
+#'                              summarizes heavy/long-chain partitions used for clustering. When grouping by
+#'                              \code{fields}, \code{summarize_clones} should be \code{FALSE}.
 #' @return
 #' If \code{summarize_clones=FALSE} (default) a modified \code{data.frame} is returned with clone identifiers in the 
 #' specified \code{clone} column.
@@ -1186,14 +1188,13 @@ hierarchicalClones <- function(db, threshold, method=c("nt", "aa"), linkage=c("s
 #' or \code{c("TRA", "TRB", "TRD", "TRG")} for TCR sequences. Otherwise, the operation will exit and 
 #' return an error message.
 #' 
-#' Under single-cell mode with paired-chain sequences, there is a choice of whether 
-#' grouping should be done by (a) using IGH (BCR) or TRB/TRD (TCR) sequences only or
-#' (b) using IGH plus IGK/IGL (BCR) or TRB/TRD plus TRA/TRG (TCR) sequences. 
-#' This is governed by the \code{only_heavy} argument. There is also choice as to whether 
-#' inferred clones should be split by the light/short chain (IGK, IGL, TRA, TRG) following 
-#' heavy/long chain clustering, which is governed by the \code{split_light} argument.
+#' In single-cell mode, clonal clustering is performed using heavy/long chains only
+#' (IGH for BCR or TRB/TRD for TCR). The \code{only_heavy=FALSE} and
+#' \code{split_light=TRUE} options are deprecated and ignored with warnings.
+#' Consequently, \code{vjl_groups} summarizes heavy/long-chain V/J/junction-length
+#' partitions and does not define groups from light/short chains.
 #' 
-#' In single-cell mode, clonal clustering will not be performed on data were cells are 
+#' In single-cell mode, clonal clustering will not be performed on data where cells are 
 #' assigned multiple heavy/long chain sequences (IGH, TRB, TRD). If observed, the operation 
 #' will exit and return an error message. Cells that lack a heavy/long chain sequence (i.e., cells with 
 #' light/short chains only) will be assigned a \code{clone_id} of \code{NA}.

--- a/R/Functions.R
+++ b/R/Functions.R
@@ -1798,13 +1798,12 @@ defineClonesScoper <- function(db,
                 db_na <- db_cloned[is.na(db_cloned[[clone]]), ]
                 db_cloned <- db_cloned[!is.na(db_cloned[[clone]]), ]
             }
-            db_cloned$clone_temp <- db_cloned %>%
-                dplyr::group_by(!!rlang::sym(clone)) %>%
-                dplyr::group_indices()
-            db_cloned[[clone]] <- db_cloned$clone_temp
-            db_cloned <- db_cloned[order(db_cloned[[clone]]), ] # Sorts them by clone_vj_group
-            db_cloned[[clone]] <- as.character(db_cloned[[clone]])
-            db_cloned$clone_temp <- NULL
+            # Clone ids are already final (assigned above, before the light chain
+            # merge); light chain rows only ever copy an existing heavy chain clone
+            # id or stay NA, so nothing needs to be renumbered. Re-sort by the
+            # existing numeric id so a clone's heavy and light chain rows sit
+            # together.
+            db_cloned <- db_cloned[order(as.integer(db_cloned[[clone]])), ]
             if (na.count > 0) {
                 db_cloned <- bind_rows(db_cloned, db_na)
             }

--- a/tests/testthat/test_clone.R
+++ b/tests/testthat/test_clone.R
@@ -809,6 +809,72 @@ test_that("Test hierarchicalClones only_heavy and first", {
         }
 })
 
+test_that("Test vjl_groups and inter_intra clone_id stay in sync with db in single-cell summarize_clones mode (issue #52)", {
+    # 3 distinct V/J/junction-length groups (A/B/C), 4 distinct heavy chain
+    # sequences each -> 12 clones total, each paired with a light chain.
+    # Deliberately >= 10 clones so that clone ids span both one and two
+    # digits ("1".."12"): a lexical (as opposed to numeric) re-sort of the
+    # character clone id column reorders "10","11","12" ahead of "2".."9".
+    heavy_junctions <- c(
+        "TCGAAATTA", "TCGAAATTC", "TCGAAATTG", "TCGAAATTT", # group A
+        "TCGCCCTTA", "TCGCCCTTC", "TCGCCCTTG", "TCGCCCTTT", # group B
+        "TCGGGGTTA", "TCGGGGTTC", "TCGGGGTTG", "TCGGGGTTT"  # group C
+    )
+    heavy_v_call <- rep(c("IGHV1-2*02", "IGHV3-23*04", "IGHV4-34*01"), each = 4)
+    heavy_j_call <- rep(c("IGHJ4*02", "IGHJ6*02", "IGHJ3*02"), each = 4)
+    n_cells <- length(heavy_junctions)
+    cell_ids <- paste0("cell", seq_len(n_cells))
+
+    db <- data.frame(
+        sequence_id = paste0("seq", seq_len(2 * n_cells)),
+        cell_id = rep(cell_ids, each = 2),
+        v_call = as.vector(rbind(heavy_v_call, rep("IGLV1*01", n_cells))),
+        j_call = as.vector(rbind(heavy_j_call, rep("IGLJ1*01", n_cells))),
+        junction = as.vector(rbind(heavy_junctions, rep("TCGTTTTTC", n_cells))),
+        stringsAsFactors = FALSE
+    )
+    db$locus <- alakazam::getLocus(db$v_call)
+    db$junction_len <- stringi::stri_length(db[["junction"]])
+
+    expect_message(
+        clones <- identicalClones(
+            db,
+            method = "nt",
+            cell_id = "cell_id",
+            locus = "locus",
+            only_heavy = TRUE,
+            summarize_clones = TRUE,
+            nproc = 1
+        ),
+        "Running defineClonesScoper in single cell mode",
+        fixed = TRUE
+    )
+
+    # Expect 12 distinct clone ids in db
+    expect_equal(length(unique(clones@db[["clone_id"]])), 12L)
+
+    # For every vjl_groups row, the clone ids it lists must, when looked up
+    # in db, actually belong to that same V/J/junction-length group. In 
+    # issue #52 clone ids pointed at unrelated group's summary rows. 
+    # vjl_groups summarizes heavy chains only, so restrict 
+    # the lookup to heavy chain rows.
+    for (i in seq_len(nrow(clones@vjl_groups))) {
+        row_clone_ids <- strsplit(clones@vjl_groups$clone_id[i], ",", fixed = TRUE)[[1]]
+        db_rows <- clones@db[clones@db[["clone_id"]] %in% row_clone_ids &
+                                  !is.na(clones@db[["clone_id"]]) &
+                                  clones@db[["locus"]] == "IGH", ]
+        expect_true(all(row_clone_ids %in% clones@db[["clone_id"]]))
+        expect_true(all(db_rows[["v_call"]] == clones@vjl_groups$v_call[i]))
+        expect_true(all(db_rows[["j_call"]] == clones@vjl_groups$j_call[i]))
+        expect_true(all(db_rows[["junction_len"]] == clones@vjl_groups$junction_length[i]))
+    }
+
+    # Consistency of inter_intra's clone ids.
+    inter_intra_ids <- unique(c(clones@inter_intra$clone_id_x, clones@inter_intra$clone_id_y))
+    inter_intra_ids <- inter_intra_ids[inter_intra_ids != "NA"]
+    expect_true(all(inter_intra_ids %in% clones@db[["clone_id"]]))
+})
+
 ## Add test for clones by light chain
 # CGJ 1/29/25 This is no longer needed as we do not split by light chains so I 
 # changed the test to best for a warning when split_lights = TRUE


### PR DESCRIPTION
- Fixes #52. In `defineClonesScoper` running in single-cell mode with `summarize_clones=TRUE`, `clone_id` values in `db` could end up out of sync with the `clone_id` values referenced in the `vjl_groups` and inter_intra summary outputs. Clone IDs were being renumbered a second time after merging light chain data, but the `vjl_groups` and inter_intra summaries already computed weren't updated to match, so they kept referencing the pre-renumbering `clone_id` values. `db_cloned` is now re-sorted by the existing (already final) `clone_id`.
- Updated documentation to clarify that `vjl_groups` summarizes heavy chain partitions. Also removed outdated text describing `only_heavy`/`split_light` as active choices when these arguments are deprecated and ignored.
